### PR TITLE
chore: cleanup build warnings

### DIFF
--- a/openbazaar-lib/src/network.rs
+++ b/openbazaar-lib/src/network.rs
@@ -1,8 +1,7 @@
 use crate::open_bazaar_api::open_bazaar_api_client::OpenBazaarApiClient;
 use crate::open_bazaar_api::{NodeAddressType, NodeLocationRequest};
 use tokio::runtime::Runtime;
-use tonic::transport::Channel;
-use tonic::{Request, Response, Status};
+use tonic::{Request, Status};
 
 #[derive(Debug, thiserror::Error)]
 pub enum NetError {

--- a/openbazaar-server/src/api.rs
+++ b/openbazaar-server/src/api.rs
@@ -5,7 +5,6 @@ use crate::network::Client;
 use crate::openbazaar::open_bazaar_rpc_server::OpenBazaarRpc;
 use crate::openbazaar::GetPeerIdRequest;
 use crate::openbazaar::GetPeerIdResponse;
-use crate::openbazaar::HashType;
 use crate::openbazaar::SaveMessageRequest;
 use crate::openbazaar::SetProfileResponse;
 use crate::openbazaar::{
@@ -17,7 +16,6 @@ use crate::profile::Profile;
 use crate::profile::ProfileData;
 use sha3::{Digest, Sha3_256};
 use tonic::{Request, Response, Status};
-use tracing::log::trace;
 use tracing::{event, instrument, Level};
 
 #[derive(Debug)]
@@ -183,14 +181,14 @@ impl<T: DB + Sync + Send + 'static> OpenBazaarRpc for OpenBazaarRpcService<T> {
 
         let pd = content.clone().profile;
 
-        let responseProfile = ProfileMessage {
+        let response_profile = ProfileMessage {
             id: pd.id,
             name: pd.name,
             email: pd.email,
         };
 
         let response = GetProfileResponse {
-            profile: Some(responseProfile),
+            profile: Some(response_profile),
         };
 
         Ok(Response::new(response))

--- a/openbazaar-server/src/crypto.rs
+++ b/openbazaar-server/src/crypto.rs
@@ -1,6 +1,7 @@
 use bdk::keys::bip39::{Language, Mnemonic};
 
-use libp2p::core::identity::ed25519;
+use libp2p::identity::ed25519;
+// use libp2p::core::identity::ed25519;
 use std::str::FromStr;
 
 pub fn generate_mnemonic() -> String {
@@ -20,8 +21,7 @@ pub fn generate_keypair_from_mnemonic(
     seed.copy_from_slice(&seed_64_bytes[0..32]);
 
     let sk = ed25519::SecretKey::from_bytes(seed).expect("not the right amount of bytes");
-    let keypair: libp2p::identity::Keypair =
-        libp2p::identity::Keypair::Ed25519(ed25519::Keypair::from(sk));
+    let keypair = ed25519::Keypair::try_from(sk)?;
 
-    Ok(keypair)
+    Ok(keypair.into())
 }

--- a/openbazaar-server/src/db.rs
+++ b/openbazaar-server/src/db.rs
@@ -79,8 +79,7 @@ impl DB for OpenBazaarDb {
     }
 
     async fn set_profile(&self, profile: &Profile) -> anyhow::Result<()> {
-        let profile = self
-            .db
+        self.db
             .insert(b"profile", bincode::serialize(profile).unwrap())?;
         Ok(())
     }

--- a/openbazaar-server/src/network.rs
+++ b/openbazaar-server/src/network.rs
@@ -370,8 +370,7 @@ impl EventLoop {
             SwarmEvent::Behaviour(ComposedEvent::Kademlia(
                 KademliaEvent::OutboundQueryProgressed {
                     id,
-                    result:
-                        QueryResult::GetRecord(Err(GetRecordError::NotFound { key, closest_peers })),
+                    result: QueryResult::GetRecord(Err(GetRecordError::NotFound { .. })),
                     ..
                 },
             )) => {

--- a/openbazaar-server/src/wallet.rs
+++ b/openbazaar-server/src/wallet.rs
@@ -4,14 +4,14 @@ use bdk::keys::{DerivableKey, ExtendedKey};
 use bdk::template::Bip84;
 use bdk::wallet::AddressIndex;
 use bdk::Wallet;
-use bdk_esplora::{esplora_client, EsploraExt};
+// use bdk_esplora::{esplora_client, EsploraExt};
 use bdk_file_store::KeychainStore;
-use std::collections::BTreeMap;
-use std::io::Write;
+// use std::collections::BTreeMap;
+// use std::io::Write;
 
-const SEND_AMOUNT: u64 = 5000;
-const STOP_GAP: usize = 50;
-const PARALLEL_REQUESTS: usize = 5;
+// const SEND_AMOUNT: u64 = 5000;
+// const STOP_GAP: usize = 50;
+// const PARALLEL_REQUESTS: usize = 5;
 
 pub fn fire_up_wallet(mnemonic_words: String, data_dir: String) {
     let network = Network::Testnet;

--- a/openbazaar-server/src/webserver.rs
+++ b/openbazaar-server/src/webserver.rs
@@ -1,21 +1,8 @@
 use async_trait::async_trait;
-use axum::extract::FromRequest;
 use axum::http::request::Parts;
-use axum::http::Request as HttpRequest;
-use axum::http::Request;
-use axum::{
-    extract::{Extension, FromRequestParts, Path},
-    http::{Response, StatusCode},
-    response::Html,
-    routing::get,
-    Router,
-};
-use axum_macros::debug_handler;
-use serde::{Deserialize, Serialize};
+use axum::{extract::FromRequestParts, http::StatusCode, routing::get, Router};
 use std::convert::Infallible;
 use std::io::Error;
-use std::sync::Arc;
-use thiserror::Error;
 use tower_http::cors::{Any, CorsLayer};
 
 struct AppUser {
@@ -38,7 +25,8 @@ where
 }
 
 pub async fn start_webserver(addr: String) -> Result<(), Error> {
-    let cors = CorsLayer::new().allow_origin(Any);
+    // fixme: cors is unused for now.
+    let _cors = CorsLayer::new().allow_origin(Any);
 
     let app = Router::new()
         .route("/", get(root))


### PR DESCRIPTION
Hi!   I'm not sure if you are ready to accept PRs or not, but this is just a simple cleanup of some build warnings that hopefully you will find an improvement.  I'm glad to see openbazaar development resume, and in rust no less!   :+1: 

--

This fixes the trivial build warnings.

note: I removed `use` statements that are unused, but I left commented anything that I found referenced in commented code below.

A couple of dead-code warnings remain, which seem useful as build-time warnings so they get resolved.  So I did not #[allow(dead_code)].